### PR TITLE
Fixing the executable name for the sphinx preparer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ python:
 install:
 - "pip install -e git+https://github.com/deconst/preparer-sphinx.git#egg=deconstrst"
 script:
-- deconst-prepare-sphinx
+- deconst-preparer-sphinx


### PR DESCRIPTION
Related to https://github.com/deconst/preparer-sphinx/pull/20
